### PR TITLE
Fix key event

### DIFF
--- a/tetnet.js
+++ b/tetnet.js
@@ -152,7 +152,7 @@ document.onLoad = initialize();
 
 
 //key options
-window.onkeydown = function () {
+window.onkeydown = function (event) {
 
 	var characterPressed = String.fromCharCode(event.keyCode);
 	if (event.keyCode == 38) {


### PR DESCRIPTION
For event to work, the onkeydown function need the event to be in parameter (at least for firefox)